### PR TITLE
Adds binutils: fixes missing readelf in mvs script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #FROM	ubuntu:18.04
 FROM	ubuntu:20.04
 
-RUN	apt-get update && \
+RUN	apt-get update binutils && \
       apt-get install -y  unzip wget && \
       cd /opt && \
       mkdir hercules && \


### PR DESCRIPTION
I was getting an error that `readelf` was missing, this led to the wrong arch being selected on my Raspberry Pi ('arm_softfloat' rather than 'arm'). This adds the binutils package which includes `readelf` so the startup script can make the right choice of architecture